### PR TITLE
refactor: move security group ids variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,8 @@ resource "aws_eks_cluster" "eks" {
   role_arn = aws_iam_role.eks_cluster.arn
 
   vpc_config {
-    subnet_ids = [aws_subnet.aks.id]
+    subnet_ids         = [aws_subnet.aks.id]
+    security_group_ids = coalescelist(var.security_group_ids, [aws_security_group.eks.id])
   }
 
   kubernetes_network_config {

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,8 +28,3 @@ output "cluster_role_arn" {
 output "subnet_ids" {
   value = var.subnet_ids
 }
-
-variable "security_group_ids" {
-  description = "List of security group IDs"
-  type        = list(string)
-}

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "subnet_ids" {
   default     = []
 }
 
+variable "security_group_ids" {
+  description = "IDs de los security groups"
+  type        = list(string)
+  default     = []
+}
+
 variable "desired_node_count" {
   description = "Número de nodos en el node group"
   type        = number


### PR DESCRIPTION
## Summary
- remove misplaced `security_group_ids` variable from `outputs.tf`
- add `security_group_ids` input variable with default and use in EKS `vpc_config`

## Testing
- `terraform init -backend=false` *(fails: Failed to query available provider packages: Forbidden)*
- `terraform plan -input=false -refresh=false` *(fails: Backend initialization required)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c4d68cf08328bfed0dab231437f4