### PR TITLE
Add second subnet for multi-AZ EKS

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -7,9 +7,9 @@
 #                 [-backend-config="dynamodb_table=<TABLA_DYNAMODB>"]
 terraform {
   backend "s3" {
-    bucket = "tfstate-demo-yourunique123"
-    key    = "eks-demo/terraform.tfstate"
-    region = "us-east-1"
+    bucket         = "tfstate-demo-yourunique123"
+    key            = "eks-demo/terraform.tfstate"
+    region         = "us-east-1"
     dynamodb_table = "tfstate-locks"
     encrypt        = true
   }

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_eks_cluster" "eks" {
   role_arn = aws_iam_role.eks_cluster.arn
 
   vpc_config {
-    subnet_ids         = [aws_subnet.aks.id]
+    subnet_ids         = [aws_subnet.aks.id, aws_subnet.aks2.id]
     security_group_ids = coalescelist(var.security_group_ids, [aws_security_group.eks.id])
   }
 
@@ -81,7 +81,7 @@ resource "aws_eks_node_group" "node_group" {
   cluster_name    = aws_eks_cluster.eks.name
   node_group_name = "${var.cluster_name}-nodes"
   node_role_arn   = aws_iam_role.eks_node.arn
-  subnet_ids      = [aws_subnet.aks.id]
+  subnet_ids      = [aws_subnet.aks.id, aws_subnet.aks2.id]
 
   scaling_config {
     desired_size = var.desired_node_count
@@ -107,10 +107,19 @@ resource "aws_vpc" "main" {
 # Subnet
 ############################
 resource "aws_subnet" "aks" {
-  vpc_id     = aws_vpc.main.id
-  cidr_block = var.eks_subnet_cidr
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.eks_subnet_cidr
+  availability_zone = "${var.aws_region}a"
 
-  tags = merge(var.tags, { Name = "${var.name_prefix}-subnet" })
+  tags = merge(var.tags, { Name = "${var.name_prefix}-subnet-a" })
+}
+
+resource "aws_subnet" "aks2" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.eks_subnet_cidr2
+  availability_zone = "${var.aws_region}b"
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-subnet-b" })
 }
 
 ############################

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,10 @@ output "subnet_id" {
   value = aws_subnet.aks.id
 }
 
+output "subnet_id_2" {
+  value = aws_subnet.aks2.id
+}
+
 output "security_group_id" {
   value = aws_security_group.eks.id
 }
@@ -26,5 +30,5 @@ output "cluster_role_arn" {
 }
 
 output "subnet_ids" {
-  value = var.subnet_ids
+  value = [aws_subnet.aks.id, aws_subnet.aks2.id]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "eks_subnet_cidr" {
   default     = "10.240.1.0/24"
 }
 
+variable "eks_subnet_cidr2" {
+  description = "CIDR de la segunda subnet"
+  type        = string
+  default     = "10.240.2.0/24"
+}
+
 variable "tags" {
   description = "Tags comunes"
   type        = map(string)
@@ -29,11 +35,6 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable "subnet_ids" {
-  description = "IDs de las subnets donde desplegar el clúster"
-  type        = list(string)
-  default     = []
-}
 
 variable "security_group_ids" {
   description = "IDs de los security groups"


### PR DESCRIPTION
## Summary
- add dedicated subnet in a second AZ and wire it into EKS cluster and node group
- expose both subnet IDs and remove unused subnet_ids variable

## Testing
- `terraform fmt`
- `terraform init -backend=false` *(fails: Failed to query available provider packages: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: registry.terraform.io/hashicorp/aws: there is no package for registry.terraform.io/hashicorp/aws 5.100.0 cached)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc4c17cc8328806398d8985a4136