### PR TITLE
docs: document AWS EKS components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Terraform · AKS + VNet + NSG (with Amazon S3 backend)
+# Terraform · EKS + VPC + Security Group (with Amazon S3 backend)
 
-This project deploys, using **Terraform**:
+This project uses **Terraform** to provision:
 
-* **Resource Group**
-* **Virtual Network (VNet)** with a dedicated **Subnet** for AKS
-* **Network Security Group (NSG)** attached to the subnet
-* **Azure Kubernetes Service (AKS)** with RBAC enabled, Azure CNI networking, and a VMSS-based system node pool
+* **Amazon VPC** with a configurable CIDR range
+* Two **subnets** spread across availability zones
+* A **security group** for cluster and load balancer traffic
+* An **Amazon EKS cluster**
+* A managed **node group**
 
-The project also configures a **remote backend** in **Amazon S3** (with optional **DynamoDB** locking) to store the **Terraform state**.
+Terraform state is stored remotely in **Amazon S3** (optionally using **DynamoDB** for state locking).
 
 ---
 
@@ -15,42 +16,38 @@ The project also configures a **remote backend** in **Amazon S3** (with optional
 
 ```
 .
-├─ backend.tf                  # Remote backend config in AWS S3 (opcional DynamoDB para bloqueo)
-├─ main.tf                     # RG, VNet, Subnet, NSG, and AKS cluster
+├─ backend.tf                  # Remote backend config in AWS S3
+├─ main.tf                     # VPC, subnets, security group, EKS cluster and node group
 ├─ variables.tf                # Deployment variables
-├─ outputs.tf                  # Outputs (RG, AKS, VNet/Subnet/NSG IDs)
-└─ terraform.tfvars.example    # Example variable values (copy/rename to terraform.tfvars)
+├─ outputs.tf                  # Outputs (VPC, subnets, cluster info)
+└─ terraform.tfvars.example    # Example variable values (copy to terraform.tfvars)
 ```
 
-> **Note:** In `backend.tf` the backend is configured for **Amazon S3**. Proporciona el bucket, la región y (opcional) la tabla de DynamoDB mediante `terraform init -backend-config`.
+> **Note:** `backend.tf` is prepared for **Amazon S3**. Provide the bucket, region and optional DynamoDB table when running `terraform init`.
 
 ---
 
 ## ✅ Prerequisites
 
-* **Azure CLI** (logged in with the right subscription)
-* **AWS CLI** (configurado con credenciales para S3/DynamoDB)
+* **AWS CLI** configured with credentials
+* **kubectl**
 * **Terraform** ≥ 1.6
-* Permissions to:
-
-  * Create **Resource Groups** and **AKS clusters** en Azure
-  * Create **S3 buckets** y (opcional) **tablas de DynamoDB** en AWS
 
 ---
 
-## 🪣 Create el backend en S3
+## 🪣 Create the backend in S3
 
-Crea un bucket en S3 para almacenar el estado de Terraform (reemplaza los valores de ejemplo):
+Create a bucket to store the Terraform state (replace placeholders):
 
 ```bash
-aws s3api create-bucket --bucket <MI_BUCKET> --region <REGION> --create-bucket-configuration LocationConstraint=<REGION>
+aws s3api create-bucket --bucket <MY_BUCKET> --region <REGION> --create-bucket-configuration LocationConstraint=<REGION>
 ```
 
-(Opcional) Crea una tabla de DynamoDB para el bloqueo de estado:
+(Optional) create a DynamoDB table for state locking:
 
 ```bash
 aws dynamodb create-table \
-  --table-name <TABLA_DYNAMODB> \
+  --table-name <DYNAMODB_TABLE> \
   --attribute-definitions AttributeName=LockID,AttributeType=S \
   --key-schema AttributeName=LockID,KeyType=HASH \
   --billing-mode PAY_PER_REQUEST \
@@ -59,59 +56,47 @@ aws dynamodb create-table \
 
 ---
 
-## 🚀 Deploy the AKS cluster (Terraform)
+## 🚀 Deploy the EKS cluster
 
 ### 1) Initialize Terraform
 
 ```bash
-cd terraform-aks-demo
 terraform init \
-  -backend-config="bucket=<MI_BUCKET>" \
-  -backend-config="key=aks-demo/terraform.tfstate" \
+  -backend-config="bucket=<MY_BUCKET>" \
+  -backend-config="key=eks-demo/terraform.tfstate" \
   -backend-config="region=<REGION>" \
-  [-backend-config="dynamodb_table=<TABLA_DYNAMODB>"] \
+  [-backend-config="dynamodb_table=<DYNAMODB_TABLE>"] \
   -reconfigure
 ```
 
-Terraform configurará el backend para usar el bucket de S3 (y la tabla de DynamoDB si se proporciona).
-
 ### 2) Review the plan
 
-```powershell
+```bash
 terraform plan -var-file="terraform.tfvars.example"
 ```
 
 ### 3) Apply the configuration
 
-```powershell
+```bash
 terraform apply -var-file="terraform.tfvars.example" -auto-approve
 ```
 
-### 4) Connect to the AKS cluster
+### 4) Connect to the EKS cluster
 
-```powershell
-# Capture outputs
-$rg  = terraform output -raw resource_group_name
-$aks = terraform output -raw aks_name
+```bash
+# capture outputs
+cluster_name=$(terraform output -raw cluster_name)
+aws eks update-kubeconfig --region <REGION> --name "$cluster_name"
 
-# Get AKS credentials for kubectl
-az aks get-credentials --resource-group $rg --name $aks
-
-# Validate
+# validate
 kubectl get nodes -o wide
-@@ -154,84 +133,25 @@ In `kube-system` you should see:
-* **azure-ip-masq-agent**
-* **azure-cni pods**
-* **metrics-server** (if enabled)
-* **omsagent/ama-**\* (if monitoring enabled)
+```
 
 ---
 
 ## 🧹 Cleanup
 
-To remove all resources:
-
-```powershell
+```bash
 terraform destroy -var-file="terraform.tfvars.example" -auto-approve
 ```
 
@@ -119,8 +104,7 @@ terraform destroy -var-file="terraform.tfvars.example" -auto-approve
 
 ## ✅ Conclusions
 
-* The project deploys a complete **basic production-ready AKS infrastructure** with networking and security.
-* We ran into issues with **unregistered providers**, **quotas**, and **availability zones**, all solved.
-* The infrastructure is ready to extend with **ACR**, **monitoring add-ons**, or **additional node pools**.
+* The project deploys a basic **EKS** environment ready for workloads.
+* Remote state is stored in **Amazon S3** and can use **DynamoDB** for locking.
+* The infrastructure can be extended with additional node groups, networking rules and add-ons.
 
----


### PR DESCRIPTION
## Summary
- rewrite README to describe AWS VPC, subnets, security group, EKS cluster, and node group
- drop Azure/AKS instructions in favour of AWS-focused setup

## Testing
- `terraform fmt -check`
- `terraform init -backend=false` *(fails: Failed to query available provider packages)*
- `terraform validate` *(fails: no cached provider package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e5f17d688328b8c1484181ba2e25