### PR TITLE
chore: streamline EKS Terraform variables

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,23 +1,20 @@
 cluster_name = "eks-demo"
 name_prefix  = "tfeks"
-region       = "us-east-1"
-availability_zones = ["1", "2"]
+aws_region   = "us-east-1"
 
-vpc_cidr        = "10.240.0.0/16"
+vnet_cidr       = "10.240.0.0/16"
 eks_subnet_cidr = "10.240.1.0/24"
+eks_subnet_cidr2 = "10.240.2.0/24"
 
-node_count    = 1
-instance_type = "t3.medium"
+desired_node_count = 1
+node_instance_type = "t3.medium"
 
-service_cidr       = "10.2.0.0/16"
-dns_service_ip     = "10.2.0.10"
-docker_bridge_cidr = "172.17.0.1/16"
+service_ipv4_cidr = "10.100.0.0/16"
 
-oidc_issuer_enabled       = true
-workload_identity_enabled = true
+# security_group_ids = []
 
 tags = {
-  project = "terraform-aks-demo"
+  project = "terraform-eks-demo"
   owner   = "fabian.clavijo"
   env     = "demo"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,7 @@ variable "aws_region" {
   type        = string
   default     = "us-east-1"
 }
+
 variable "vnet_cidr" {
   description = "CIDR de la VPC"
   type        = string
@@ -29,12 +30,6 @@ variable "tags" {
     env     = "demo"
   }
 }
-variable "region" {
-  description = "Región de AWS"
-  type        = string
-  default     = "us-east-1"
-}
-
 
 variable "security_group_ids" {
   description = "IDs de los security groups"
@@ -59,6 +54,7 @@ variable "service_ipv4_cidr" {
   type        = string
   default     = "10.100.0.0/16"
 }
+
 variable "cluster_name" {
   description = "Nombre del clúster EKS"
   type        = string
@@ -69,60 +65,4 @@ variable "name_prefix" {
   description = "Prefijo para nombres de recursos"
   type        = string
   default     = "tfeks"
-}
-
-variable "vpc_cidr" {
-  description = "CIDR de la VPC"
-  type        = string
-  default     = "10.240.0.0/16"
-}
-
-variable "node_count" {
-  description = "Número de nodos en el node pool"
-  type        = number
-  default     = 1
-}
-
-variable "instance_type" {
-  description = "Tipo de instancia para los nodos"
-  type        = string
-  default     = "t3.medium"
-}
-
-variable "availability_zones" {
-  description = "Zonas de disponibilidad para el node pool (opcional)"
-  type        = list(string)
-  default     = ["1", "2"]
-}
-
-# Red de servicios de Kubernetes (no debe solaparse con la VNet)
-variable "service_cidr" {
-  description = "CIDR para servicios de Kubernetes"
-  type        = string
-  default     = "10.2.0.0/16"
-}
-
-variable "dns_service_ip" {
-  description = "IP del CoreDNS dentro del service CIDR"
-  type        = string
-  default     = "10.2.0.10"
-}
-
-variable "docker_bridge_cidr" {
-  description = "CIDR del docker bridge en nodos"
-  type        = string
-  default     = "172.17.0.1/16"
-}
-
-# Features opcionales
-variable "oidc_issuer_enabled" {
-  description = "Habilitar OIDC issuer para federación"
-  type        = bool
-  default     = true
-}
-
-variable "workload_identity_enabled" {
-  description = "Habilitar Workload Identity"
-  type        = bool
-  default     = true
 }


### PR DESCRIPTION
## Summary
- remove redundant variable definitions
- consolidate example tfvars to canonical names

## Testing
- `terraform fmt -check`
- `terraform init -backend=false` *(fails: Failed to query available provider packages)*
- `terraform validate` *(fails: registry.terraform.io/hashicorp/aws: there is no package for registry.terraform.io/hashicorp/aws 5.100.0 cached)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e6f517b08328b961f0d3cba7cb58