### PR TITLE
Tag EKS worker subnets for cluster and internal load balancers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,14 @@ resource "aws_subnet" "aks" {
   cidr_block        = var.eks_subnet_cidr
   availability_zone = "${var.aws_region}a"
 
-  tags = merge(var.tags, { Name = "${var.name_prefix}-subnet-a" })
+  tags = merge(
+    var.tags,
+    {
+      Name                                        = "${var.name_prefix}-subnet-a"
+      "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+      "kubernetes.io/role/internal-elb"           = "1"
+    }
+  )
 }
 
 resource "aws_subnet" "aks2" {
@@ -119,7 +126,14 @@ resource "aws_subnet" "aks2" {
   cidr_block        = var.eks_subnet_cidr2
   availability_zone = "${var.aws_region}b"
 
-  tags = merge(var.tags, { Name = "${var.name_prefix}-subnet-b" })
+  tags = merge(
+    var.tags,
+    {
+      Name                                        = "${var.name_prefix}-subnet-b"
+      "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+      "kubernetes.io/role/internal-elb"           = "1"
+    }
+  )
 }
 
 ############################


### PR DESCRIPTION
## Summary
- tag worker subnets with EKS cluster and internal ELB identifiers

## Testing
- `terraform fmt -check main.tf`
- `terraform init -backend=false` *(fails: Failed to query available provider packages: Forbidden)*
- `terraform validate` *(fails: no cached package for hashicorp/aws 5.100.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fecc734c832893d3a9f70d348d41