### PR TITLE
Add SSM policy attachment for EKS nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,11 @@ resource "aws_iam_role_policy_attachment" "eks_node_registry" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
+resource "aws_iam_role_policy_attachment" "eks_node_ssm" {
+  role       = aws_iam_role.eks_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 resource "aws_eks_node_group" "node_group" {
   cluster_name    = aws_eks_cluster.eks.name
   node_group_name = "${var.cluster_name}-nodes"


### PR DESCRIPTION
## Summary
- allow EKS node role to use AWS Systems Manager by attaching `AmazonSSMManagedInstanceCore`

## Testing
- `terraform init` *(fails: No valid credential sources found)*
- `terraform plan` *(fails: Backend initialization required)*
- `terraform apply -auto-approve` *(fails: Backend initialization required)*
- `aws iam list-attached-role-policies --role-name dummy` *(fails: Unable to locate credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c6093bdc84832898c5b83feb4be022