### PR TITLE
Enable DNS hostnames in VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,9 @@ resource "aws_eks_node_group" "node_group" {
 # VPC
 ############################
 resource "aws_vpc" "main" {
-  cidr_block = var.vnet_cidr
+  cidr_block           = var.vnet_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
 
   tags = merge(var.tags, { Name = "${var.name_prefix}-vpc" })
 }


### PR DESCRIPTION
## Summary
- enable DNS support and hostnames for main VPC

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform plan -var-file=terraform.tfvars.example` *(fails: Backend initialization required)*

------
https://chatgpt.com/codex/tasks/task_e_68c617b900a88328915578a9363c818f