### PR TITLE
Add public subnet and routing for VPC

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,11 @@ output "cluster_role_arn" {
 output "subnet_ids" {
   value = [aws_subnet.aks.id, aws_subnet.aks2.id]
 }
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}
+
+output "public_route_table_id" {
+  value = aws_route_table.public.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "eks_subnet_cidr2" {
   default     = "10.240.2.0/24"
 }
 
+variable "public_subnet_cidr" {
+  description = "CIDR de la subnet pública"
+  type        = string
+  default     = "10.240.0.0/24"
+}
+
 variable "tags" {
   description = "Tags comunes"
   type        = map(string)


### PR DESCRIPTION
## Summary
- add configurable `public_subnet_cidr`
- provision internet gateway, public subnet, and route table
- expose new subnet and route table IDs

## Testing
- `terraform fmt -check`
- `terraform init -backend=false` *(fails: Forbidden)*
- `terraform validate` *(fails: no cached provider)*

------
https://chatgpt.com/codex/tasks/task_e_68c6187d0dbc8328b3ab2860f0e05bbb