### PR TITLE
Expose gateway and route table IDs in outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -40,3 +40,16 @@ output "public_subnet_id" {
 output "public_route_table_id" {
   value = aws_route_table.public.id
 }
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_id" {
+  value = aws_nat_gateway.this.id
+}
+
+output "private_route_table_id" {
+  value = aws_route_table.private.id
+}
+


### PR DESCRIPTION
## Summary
- expose internet gateway, NAT gateway and private route table IDs as Terraform outputs

## Testing
- `terraform fmt -diff -check`
- `terraform init` *(fails: No valid credential sources found)*
- `terraform plan -refresh=false` *(fails: Backend initialization required)*

------
https://chatgpt.com/codex/tasks/task_e_68c61a3727308328955f615e771183ee